### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ Markdown==2.6.5
 click==6.2
 gfm==0.0.3
 html2text==2015.11.4
-lxml==3.5.0
+lxml==4.5.2
 py-gfm==0.1.1
 watchdog==0.8.3
 Pygments==2.1.3
 websocket-server==0.4
+requests=2.24.0

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ setup(
     name='nom',
     version='1.4.0',
     description='tool for managing markdown notes',
+    package_data={'': ['templates/*']},
+    include_package_data=True,
     url='https://github.com/frnsys/nom',
     author='Francis Tseng',
     author_email='f@frnsys.com',
@@ -21,7 +23,7 @@ setup(
         'watchdog==0.8.3',
         'Pygments==2.1.3',
         'websocket-server==0.4',
-        'requests=2.24.0'
+        'requests==2.24.0'
     ],
     entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,13 @@ setup(
         'Markdown==2.6.5',
         'click==6.2',
         'gfm==0.0.3',
+        'lxml==4.5.2',
         'html2text==2015.11.4',
-        'lxml==3.5.0',
         'py-gfm==0.1.1',
         'watchdog==0.8.3',
         'Pygments==2.1.3',
-        'websocket-server==0.4'
+        'websocket-server==0.4',
+        'requests=2.24.0'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
I love this; super simple, barebones, but really useful for managing md. I wrapped this in Docker to work out dependencies from a clean slate, and it seems requests is missing from the explicit dependencies.

I also had some trouble installing lxml on ubuntu/debian, both from apt listings and from source. Updating the version to 3.5 (the latest) makes install work more smoothly. Is there a reason that lxml needs to be tied to version 2.5?

I've added both requests and the lxml version bump to both requirements.txt and setup.py. Let me know if anything needs changing!